### PR TITLE
Bump named-arrays to ~=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "astropy",
     "sunpy",
     "aiapy",
-    "named-arrays>=0.21.0",
+    "named-arrays~=2.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Update the `named-arrays` pin from `>=0.21.0` to `~=2.0` following the release of named-arrays 2.0.0, requiring (and capping) the new breaking major version.

`pytest sdo` passes (8 tests) against the named-arrays 2.0 API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)